### PR TITLE
chore: project template review and improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Something isn't working as expected
+labels: bug
+---
+
+**What happened?**
+A clear description of the bug.
+
+**Steps to reproduce**
+1. 
+2. 
+3. 
+
+**Expected behaviour**
+What did you expect to happen?
+
+**Environment**
+- OS:
+- Version/commit:
+
+**Additional context**
+Logs, screenshots, or anything else that might help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+labels: enhancement
+---
+
+**What problem does this solve?**
+A clear description of the problem or limitation.
+
+**Proposed solution**
+What would you like to see happen?
+
+**Alternatives considered**
+Any other approaches you've thought about?
+
+**Additional context**
+Anything else worth knowing.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## What does this PR do?
+
+<!-- A short description of the change and why it's needed. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactor / chore
+
+## Checklist
+
+- [ ] I've tested my changes
+- [ ] I've updated documentation if needed
+- [ ] Commits are signed (`git commit -s`)

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,31 @@
-.DS_Store 
+# ============================================================
+# Universal patterns — safe for every project regardless of stack
+# ============================================================
 
-.env 
+# OS
+.DS_Store
+Thumbs.db
+Desktop.ini
 
+# Secrets & credentials
+.env
+.env.*
+*.pem
+*.key
+*.p12
+*.pfx
+
+# Editors & IDEs
 .vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# ============================================================
+# Stack-specific patterns
+# Generate and paste your block below using:
+#   https://www.gitignore.io
+# or pick a template from:
+#   https://github.com/github/gitignore
+# ============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - [TODO: Release date]
+
+### Added
+
+- Initial release
+
+[unreleased]: https://github.com/[TODO: YOUR-USERNAME]/[TODO: YOUR-REPO]/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/[TODO: YOUR-USERNAME]/[TODO: YOUR-REPO]/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[dimitri.kandassamy+conduct@gmail.com](mailto:dimitri.kandassamy+conduct@gmail.com).
+[TODO: Add your enforcement contact email address].
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ Please note that this project is released with a [Contributor Code of Conduct](.
 
 ### DCO
 
+<!-- TODO: DCO is enabled by default. Remove this section if it doesn't suit your project. -->
+
 Licensing is important to open source projects. It provides some assurances that
 the software will continue to be available based under the terms that the
 author(s) desired. We require that contributors sign off on commits submitted to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,28 @@ repository, you can amend your commit with the sign-off by running
 
     git commit --amend -s
 
+## License Headers
+
+When adding new source files, include the Apache 2.0 license header at the top:
+
+```
+Copyright [YEAR] [TODO: Your name or organisation]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
+<!-- TODO: Remove this section if you use a tool (e.g. addlicense, Licensee) to manage headers automatically. -->
+
 ## Submit changes
 
 Please send a Pull Request with an explanation of what you've done.

--- a/README-template.md
+++ b/README-template.md
@@ -1,41 +1,39 @@
-# [TODO:Projectname]
+# [TODO: Project name]
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](./CODE_OF_CONDUCT.md)
 
-<!-- Mission Statement -->
+[TODO: Project name] is a [TODO: type of tool] that [TODO: describe what it does]. [TODO: Why it's needed and what value it provides]. [TODO: Briefly describe the implementation approach or architecture].
 
-[TODO: PROJECTNAME] is a [TODO: Type of Tool] that [TODO: Functions it
-performs].  [TODO: Reasons why these are needed and valuable].  [TODO:
-Implementation, strategy and architecture].
-
-[TODO: Additional paragraph describing your project (optional)]
+[TODO: Optional second paragraph with more detail]
 
 ## Getting Started 🚀
 
 ### Prerequisites
 
 ```
-
+[TODO: List prerequisites e.g. runtime version, required tools]
 ```
 
 ### Installation
 
 1. Add your stack-specific `.gitignore` patterns — generate them at [gitignore.io](https://www.gitignore.io) and append to the existing `.gitignore`
 
-1. Clone the repo
+2. Clone the repo
 
    ```
-
+   [TODO: git clone command]
    ```
 
-2. Install
+3. Install
 
    ```
-
+   [TODO: install command]
    ```
 
 ## Usage
+
+[TODO: Show a minimal example of how to use the project]
 
 ## Roadmap
 
@@ -56,8 +54,8 @@ This project is licensed under [Apache 2.0](./LICENSE)
 
 ## Contact
 
+[TODO: Add your contact info or a link to the project's discussion channel]
+
 ## Acknowledgments
 
-- []()
-- []()
-- []()
+- [TODO: Credit libraries, tools, or people that helped]

--- a/README-template.md
+++ b/README-template.md
@@ -21,6 +21,8 @@ Implementation, strategy and architecture].
 
 ### Installation
 
+1. Add your stack-specific `.gitignore` patterns — generate them at [gitignore.io](https://www.gitignore.io) and append to the existing `.gitignore`
+
 1. Clone the repo
 
    ```

--- a/README-template.md
+++ b/README-template.md
@@ -42,7 +42,7 @@ Implementation, strategy and architecture].
 - [ ] Feature 3
   - [ ] Nested Feature
 
-See the [open issues](https://github.com/github_username/repo_name/issues) for a full list of proposed features (and known issues).
+See the [open issues](https://github.com/[TODO: YOUR-USERNAME]/[TODO: YOUR-REPO]/issues) for a full list of proposed features (and known issues).
 
 ## Contributing
 

--- a/README-template.md
+++ b/README-template.md
@@ -7,7 +7,7 @@
 
 [TODO: Optional second paragraph with more detail]
 
-## Getting Started 🚀
+## Getting Started
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -9,17 +9,22 @@ This template uses the Apache license as a default.
 
 ## How to use this template
 
-1. Click **Use this template** on Github and create a copy of this repository.
-2. Copy the content of `README-template.md` into `README.md`
-3. Customize according to your project
+1. Click **Use this template** on GitHub and create a copy of this repository.
+2. Replace the contents of `README.md` with the contents of `README-template.md`, then delete `README-template.md`.
+3. Fill in all `[TODO: ...]` placeholders across every file.
+4. Update `CHANGELOG.md` with your project's release history.
+5. Customize or remove any files that don't fit your project.
 
 ## Project Resources
 
-| Resource                                   | Description                                                                                              |
-| :----------------------------------------- | :------------------------------------------------------------------------------------------------------- |
-| [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) | Expected behavior for project contributors, promoting a welcoming environment (Contributor Covenant 2.1) |
-| [CONTRIBUTING.md](./CONTRIBUTING.md)       | Developer guide to build, test, run, access CI, chat, discuss, file issues                               |
-| [LICENSE](./LICENSE)                       | Apache License, Version 2.0                                                                              |
+| Resource                                             | Description                                                                                              |
+| :--------------------------------------------------- | :------------------------------------------------------------------------------------------------------- |
+| [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)           | Expected behavior for project contributors, promoting a welcoming environment (Contributor Covenant 2.1) |
+| [CONTRIBUTING.md](./CONTRIBUTING.md)                 | Contribution guidelines including DCO sign-off and commit signing                                        |
+| [SECURITY.md](./SECURITY.md)                         | Vulnerability reporting policy and disclosure process                                                    |
+| [CHANGELOG.md](./CHANGELOG.md)                       | Release history following Keep a Changelog format                                                        |
+| [LICENSE](./LICENSE)                                 | Apache License, Version 2.0                                                                              |
+| [.github/](./.github/)                               | Issue templates (bug report, feature request) and pull request template                                  |
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest  | ✅        |
+
+<!-- TODO: Update this table once you establish a versioning and support policy. -->
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+To report a vulnerability, email [TODO: Add your security contact email] with:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept
+- Any suggested mitigations if you have them
+
+You should receive a response within **72 hours**. If you do not, follow up to make sure your message was received.
+
+<!-- TODO: Adjust the response-time commitment to match what you can realistically maintain. -->
+
+## Disclosure Policy
+
+Once a fix is available, we will:
+
+1. Release a patched version
+2. Publish a security advisory on GitHub
+3. Credit the reporter (unless they prefer to remain anonymous)


### PR DESCRIPTION
## Summary

Full review of the template repository surfaced several issues — critical privacy concerns, missing standard files, and inconsistencies. This PR fixes them all.

## Changes by priority

**Critical fixes**
- Replace hardcoded personal email in `CODE_OF_CONDUCT.md` with a `[TODO: ...]` placeholder — every project forked from this template would have inherited it
- Replace hardcoded `github_username/repo_name` in `README-template.md` with explicit `[TODO: YOUR-USERNAME]` / `[TODO: YOUR-REPO]` placeholders

**Missing standard files**
- Add `SECURITY.md` with a private disclosure channel and response-time commitment (GitHub surfaces this in the Security tab)
- Add `CHANGELOG.md` following Keep a Changelog / SemVer format
- Add `.github/` with bug report and feature request issue templates, PR template, and `config.yml`

**`.gitignore`**
- Expand with universal OS, secrets, and editor patterns
- Add a comment block pointing to gitignore.io for stack-specific patterns — keeps the file lean for a tech-agnostic template

**`README-template.md` cleanup**
- Standardise all `[TODO: ...]` markers (consistent spacing, sentence case)
- Reflow multi-line TODO sentences onto single lines
- Fix duplicate list item `1.` in Installation
- Remove orphaned HTML comment
- Add placeholder text to empty Contact and Acknowledgments sections
- Add inline hints to empty code blocks
- Remove lone 🚀 emoji (only heading that had one)

**`README.md`**
- Add explicit step to delete `README-template.md` after setup
- Add steps for filling in TODOs, updating CHANGELOG, and pruning files
- Update resources table to include SECURITY.md, CHANGELOG.md, and .github/

**`CONTRIBUTING.md`**
- Mark the DCO section as optional via a TODO comment
- Add Apache 2.0 license header boilerplate and guidance

## Test plan

- [x] Walk through the setup steps in `README.md` end-to-end on a fresh repo created from this template
- [x] Confirm all `[TODO: ...]` placeholders are present and consistently formatted
- [x] Verify GitHub surfaces `SECURITY.md` in the Security tab
- [x] Verify `.github/` issue and PR templates appear when opening issues/PRs